### PR TITLE
Fix(kuz_wrap):Включение ready и err в access phase

### DIFF
--- a/rtl/kuznechik_cipher_apb_wrapper.sv
+++ b/rtl/kuznechik_cipher_apb_wrapper.sv
@@ -270,9 +270,9 @@ module kuznechik_cipher_apb_wrapper
   // APB ready            //
   //////////////////////////
 
-  assign apb_ready_next = apb_psel_i & ~apb_penable_i;
+  assign apb_ready_next = ( apb_psel_i & apb_penable_i ) & ~apb_ready_ff;
 
-  assign apb_ready_en = (apb_psel_i & ~apb_penable_i)
+  assign apb_ready_en = (apb_psel_i & apb_penable_i)
                       | apb_ready_ff;
 
   always_ff @(posedge clk_i or negedge rstn_i)
@@ -305,7 +305,7 @@ module kuznechik_cipher_apb_wrapper
                       & ~(apb_sel_data_out_3 & ~apb_pwrite_i);
 
 
-  assign apb_err_en = (apb_psel_i & ~apb_penable_i);
+  assign apb_err_en = (apb_psel_i & apb_penable_i);
 
   always_ff @(posedge clk_i or negedge rstn_i)
   if (~rstn_i)


### PR DESCRIPTION
А не в setup phase. Тк в pulpino access и setup phase совпадают по времени( en и sel устанавливаются одновременно ), то setup по факту нет.<br>
![image](https://user-images.githubusercontent.com/53278658/232015986-f74e736f-6192-49b2-baeb-9ae2587a7843.png)
Также исправленная версия будет работать и с нормальной реализацией apb.
